### PR TITLE
Add Sponsors collection

### DIFF
--- a/src/collections/Sponsors.ts
+++ b/src/collections/Sponsors.ts
@@ -1,0 +1,70 @@
+import type { CollectionConfig } from 'payload'
+
+import { anyone } from '../access/anyone'
+import { authenticated } from '../access/authenticated'
+
+export const Sponsors: CollectionConfig = {
+  slug: 'sponsors',
+  access: {
+    create: authenticated,
+    delete: authenticated,
+    read: anyone,
+    update: authenticated,
+  },
+  admin: {
+    useAsTitle: 'code',
+  },
+  fields: [
+    {
+      name: 'code',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      minLength: 1,
+      maxLength: 50,
+      validate: (val) => {
+        const value = val as string
+        if (!value) return 'Code is required'
+        if (!/^[a-z_]{1,50}$/.test(value)) {
+          return 'Only lowercase letters and underscores are allowed'
+        }
+        return true
+      },
+    },
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+      localized: true,
+    },
+    {
+      name: 'logo',
+      type: 'group',
+      localized: true,
+      fields: [
+        {
+          name: 'default',
+          type: 'upload',
+          relationTo: 'media',
+        },
+        {
+          name: 'black',
+          label: 'Black version',
+          type: 'upload',
+          relationTo: 'media',
+        },
+        {
+          name: 'white',
+          label: 'White version',
+          type: 'upload',
+          relationTo: 'media',
+        },
+      ],
+    },
+    {
+      name: 'backgroundColor',
+      type: 'text',
+    },
+  ],
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     pages: Page;
     posts: Post;
+    sponsors: Sponsor;
     media: Media;
     categories: Category;
     users: User;
@@ -85,6 +86,7 @@ export interface Config {
   collectionsSelect: {
     pages: PagesSelect<false> | PagesSelect<true>;
     posts: PostsSelect<false> | PostsSelect<true>;
+    sponsors: SponsorsSelect<false> | SponsorsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
@@ -729,6 +731,23 @@ export interface Form {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "sponsors".
+ */
+export interface Sponsor {
+  id: string;
+  code: string;
+  name: string;
+  logo?: {
+    default?: (string | null) | Media;
+    black?: (string | null) | Media;
+    white?: (string | null) | Media;
+  };
+  backgroundColor?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "redirects".
  */
 export interface Redirect {
@@ -907,6 +926,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'posts';
         value: string | Post;
+      } | null)
+    | ({
+        relationTo: 'sponsors';
+        value: string | Sponsor;
       } | null)
     | ({
         relationTo: 'media';
@@ -1147,6 +1170,24 @@ export interface PostsSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "sponsors_select".
+ */
+export interface SponsorsSelect<T extends boolean = true> {
+  code?: T;
+  name?: T;
+  logo?:
+    | T
+    | {
+        default?: T;
+        black?: T;
+        white?: T;
+      };
+  backgroundColor?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -10,6 +10,7 @@ import { Categories } from './collections/Categories'
 import { Media } from './collections/Media'
 import { Pages } from './collections/Pages'
 import { Posts } from './collections/Posts'
+import { Sponsors } from './collections/Sponsors'
 import { Users } from './collections/Users'
 import { Footer } from './Footer/config'
 import { Header } from './Header/config'
@@ -62,7 +63,7 @@ export default buildConfig({
   db: mongooseAdapter({
     url: process.env.DATABASE_URI || '',
   }),
-  collections: [Pages, Posts, Media, Categories, Users],
+  collections: [Pages, Posts, Sponsors, Media, Categories, Users],
   cors: [getServerSideURL()].filter(Boolean),
   globals: [Header, Footer],
   plugins: [


### PR DESCRIPTION
## Summary
- define `Sponsors` collection for Payload
- wire it into payload config
- regenerate Payload types

## Testing
- `pnpm install`
- `pnpm generate:types`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684257a88c908331a48bd5d2eefe6c91