### PR TITLE
Allow digits in sponsor codes

### DIFF
--- a/src/collections/Sponsors.ts
+++ b/src/collections/Sponsors.ts
@@ -26,8 +26,8 @@ export const Sponsors: CollectionConfig = {
       validate: (val) => {
         const value = val as string
         if (!value) return 'Code is required'
-        if (!/^[a-z_]{1,50}$/.test(value)) {
-          return 'Only lowercase letters and underscores are allowed'
+        if (!/^[a-z0-9_]{1,50}$/.test(value)) {
+          return 'Only lowercase letters, numbers, and underscores are allowed'
         }
         return true
       },


### PR DESCRIPTION
## Summary
- relax sponsor code validation

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684259bb0ad08331a8f41b9211cd47e2