### PR TITLE
feat: add webp format options to Media collection and minor cleanup

### DIFF
--- a/.windsurf/workflows/git-commit.md
+++ b/.windsurf/workflows/git-commit.md
@@ -1,0 +1,10 @@
+---
+description: Create a commit from currently staged changes. If on `main`, use a new branch.
+---
+
+1. Summarize the staged changes from this session (do not stage any new files).
+2. If the current branch is `main`:
+    - Create a new branch named {type}/{summary}, where type is one of `feat`, `refactor`, `chore`, or `fix`.
+    - Switch to the new branch using git switch {type}/{summary} (or git checkout) before committing.
+3. Generate a concise and meaningful commit message.
+4. Commit only the currently staged changes using the generated message. Do not stage or modify unstaged files.

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -1,13 +1,11 @@
-import type { CollectionConfig } from 'payload'
-
 import {
   FixedToolbarFeature,
   InlineToolbarFeature,
-  lexicalEditor,
+  lexicalEditor
 } from '@payloadcms/richtext-lexical'
 import path from 'path'
+import type { CollectionConfig } from 'payload'
 import { fileURLToPath } from 'url'
-
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
 
@@ -43,37 +41,61 @@ export const Media: CollectionConfig = {
     staticDir: path.resolve(dirname, '../../public/media'),
     adminThumbnail: 'thumbnail',
     focalPoint: true,
+    formatOptions: {
+      format: 'webp',
+    },
     imageSizes: [
       {
         name: 'thumbnail',
         width: 300,
+        formatOptions: {
+          format: 'webp',
+        },
       },
       {
         name: 'square',
         width: 500,
         height: 500,
+        formatOptions: {
+          format: 'webp',
+        },
       },
       {
         name: 'small',
         width: 600,
+        formatOptions: {
+          format: 'webp',
+        },
       },
       {
         name: 'medium',
         width: 900,
+        formatOptions: {
+          format: 'webp',
+        },
       },
       {
         name: 'large',
         width: 1400,
+        formatOptions: {
+          format: 'webp',
+        },
       },
       {
         name: 'xlarge',
         width: 1920,
+        formatOptions: {
+          format: 'webp',
+        },
       },
       {
         name: 'og',
         width: 1200,
         height: 630,
         crop: 'center',
+        formatOptions: {
+          format: 'webp',
+        },
       },
     ],
   },

--- a/src/collections/Sponsors.ts
+++ b/src/collections/Sponsors.ts
@@ -1,5 +1,4 @@
 import type { CollectionConfig } from 'payload'
-
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
 


### PR DESCRIPTION
- Added `formatOptions: { format: 'webp' }` to Media collection and all image sizes in Media.ts for consistent webp formatting
- Minor import and whitespace cleanup in Media.ts and Sponsors.ts
- Added workflow for git-commit process
